### PR TITLE
Upgrade to duc 1.4.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,18 +16,19 @@ RUN apt-get update -qq && \
 RUN mkdir /duc && \
     mkdir /duc/db && \ 
     cd /duc && \
-    wget https://github.com/zevv/duc/releases/download/1.4.4/duc-1.4.4.tar.gz && \
-    tar xzf duc-1.4.4.tar.gz && \
-    rm duc-1.4.4.tar.gz && \
-    cd duc-1.4.4 && \
+    wget https://github.com/zevv/duc/releases/download/1.4.5/duc-1.4.5.tar.gz && \
+    tar xzf duc-1.4.5.tar.gz && \
+    rm duc-1.4.5.tar.gz && \
+    cd duc-1.4.5 && \
     ./configure && \ 
     make && \
     make install && \
     cd .. && \
-    rm -rf duc-1.4.4
+    rm -rf duc-1.4.5
 
 COPY assets/index.cgi /var/www/duc/
 COPY assets/000-default.conf /etc/apache2/sites-available/
+COPY assets/ducrc /etc/
 COPY assets/duc_startup.sh /duc/
 
 #create a starter database so that we can set permissions for cgi access

--- a/assets/ducrc
+++ b/assets/ducrc
@@ -1,0 +1,2 @@
+[global]
+database /duc/.duc.db


### PR DESCRIPTION
I added an /etc/ducrc to avoid the following when building

```
...
Step 9/15 : COPY assets/duc_startup.sh /duc/
 ---> Using cache
 ---> b4b96e078049
Step 10/15 : RUN mkdir /host && 	duc index /host/ && 	chmod 777 /duc/ && 	chmod 777 /duc/.duc.db && 	a2enmod cgi && 	chmod +x /duc/duc_startup.sh && 	chmod +x /var/www/duc/index.cgi
 ---> Running in fef41164be4b
Error opening: /duc/.cache/duc/duc.db - unsupported DB type unknown, compiled for tokyocabinet
Database not found
Removing intermediate container fef41164be4b
```